### PR TITLE
Add WaitTOF between CloseDevice/OpenDevice 

### DIFF
--- a/src/scsi.c
+++ b/src/scsi.c
@@ -236,6 +236,8 @@ static BOOL scsi_inquiry(struct IOStdReq *io, int target, int lun,
 
     /* Close and reopen device with correct unit */
     CloseDevice((struct IORequest *)io);
+    /* uaehf.device needs a delay between closing and opening again */
+    WaitTOF();
     error = OpenDevice((CONST_STRPTR)scsi_device_list.device_name, unit,
                        (struct IORequest *)io, 0);
     if (error != 0) {
@@ -299,6 +301,8 @@ static BOOL scsi_read_capacity(struct IOStdReq *io, int target, int lun,
 
     /* Close and reopen device with correct unit */
     CloseDevice((struct IORequest *)io);
+    /* uaehf.device needs a delay between closing and opening again */
+    WaitTOF();
     error = OpenDevice((CONST_STRPTR)scsi_device_list.device_name, unit,
                        (struct IORequest *)io, 0);
     if (error != 0) {


### PR DESCRIPTION
Add WaitTOF() In scsi_inqiry and scsi_read_capacity

Without this delay the program will lock up if the `scsi` button is pressed for a uaehf device