### PR TITLE
memory: allocate speed test buffers with AllocAbs

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -105,6 +105,51 @@ void analyze_memory_region(struct MemHeader *mh, ULONG *chunks, ULONG *largest)
 }
 
 /*
+ * Find the live Exec memory header for a stored region.
+ */
+static struct MemHeader *find_region_header(MemoryRegion *region)
+{
+    struct MemHeader *mh;
+
+    if (!region) return NULL;
+
+    for (mh = (struct MemHeader *)SysBase->MemList.lh_Head;
+         (struct Node *)mh != (struct Node *)&SysBase->MemList.lh_Tail;
+         mh = (struct MemHeader *)mh->mh_Node.ln_Succ) {
+        if (mh == region->memListNode ||
+            (mh->mh_Lower == region->lower_bound &&
+             mh->mh_Upper == region->upper_bound)) {
+            return mh;
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * Find the largest currently free chunk in a memory header.
+ */
+static APTR find_largest_free_chunk(struct MemHeader *mh, ULONG *size)
+{
+    struct MemChunk *mc;
+    APTR chunk = NULL;
+    ULONG largest = 0;
+
+    if (size) *size = 0;
+    if (!mh) return NULL;
+
+    for (mc = mh->mh_First; mc != NULL; mc = mc->mc_Next) {
+        if (mc->mc_Bytes > largest) {
+            largest = mc->mc_Bytes;
+            chunk = (APTR)mc;
+        }
+    }
+
+    if (size) *size = largest;
+    return chunk;
+}
+
+/*
  * Enumerate all memory regions
  */
 void enumerate_memory_regions(void)
@@ -170,24 +215,18 @@ void enumerate_memory_regions(void)
 void refresh_memory_region(ULONG index)
 {
     struct MemHeader *mh;
-    ULONG i = 0;
 
     if (index >= memory_regions.count) return;
 
     Forbid();
 
-    for (mh = (struct MemHeader *)SysBase->MemList.lh_Head;
-         (struct Node *)mh != (struct Node *)&SysBase->MemList.lh_Tail;
-         mh = (struct MemHeader *)mh->mh_Node.ln_Succ) {
-
-        if (i == index) {
-            MemoryRegion *region = &memory_regions.regions[index];
-            region->first_free = mh->mh_First;
-            region->amount_free = mh->mh_Free;
-            analyze_memory_region(mh, &region->num_chunks, &region->largest_block);
-            break;
-        }
-        i++;
+    mh = find_region_header(&memory_regions.regions[index]);
+    if (mh) {
+        MemoryRegion *region = &memory_regions.regions[index];
+        region->memListNode = mh;
+        region->first_free = mh->mh_First;
+        region->amount_free = mh->mh_Free;
+        analyze_memory_region(mh, &region->num_chunks, &region->largest_block);
     }
 
     Permit();
@@ -200,6 +239,10 @@ void refresh_memory_region(ULONG index)
 ULONG measure_memory_speed(ULONG index)
 {
     MemoryRegion *region;
+    struct MemHeader *mh;
+    APTR chunk = NULL;
+    APTR buffer = NULL;
+    ULONG chunk_size = 0;
     ULONG buffer_size;
     ULONG bytes_per_sec = 0;
 
@@ -207,75 +250,46 @@ ULONG measure_memory_speed(ULONG index)
 
     region = &memory_regions.regions[index];
 
-    /* Use a reasonable buffer size - 64K for test reads */
-    buffer_size = 64 * 1024;
+    /*
+     * Allocate from the selected region without rewriting Exec's global
+     * memory list.  AllocAbs() will fail if this exact free chunk is no
+     * longer available.
+     */
+    Forbid();
 
-    /* Limit to largest available block (halved for safety margin) */
-    if (buffer_size > region->largest_block / 2) {
-        buffer_size = region->largest_block / 2;
+    mh = find_region_header(region);
+    if (mh) {
+        region->memListNode = mh;
+        region->first_free = mh->mh_First;
+        region->amount_free = mh->mh_Free;
+        analyze_memory_region(mh, &region->num_chunks, &region->largest_block);
+        chunk = find_largest_free_chunk(mh, &chunk_size);
+    }
+
+    buffer_size = 64 * 1024;
+    if (buffer_size > chunk_size / 2) {
+        buffer_size = chunk_size / 2;
     }
 
     /* Ensure reasonable minimum size */
     if (buffer_size < 256) {
         region->speed_measured = TRUE;
         region->speed_bytes_sec = 0;
+        Permit();
         return 0;
     }
 
-    /*
-        Mega magic: I want to allocate a buffer in exactly this region (to avoid any mem corruption)
-        So what to do (according to Thomas Richter):
-
-        Forbid()
-        Fetch my entry in the System Memlist
-        Save old head and tail of memlist
-        Save prev/next-pointer of my entry
-        set head and tail to my entry
-        set prev/next-pointer of my entry to myself
-        alloc mem (there is only one entry left!)
-        restore all pointers
-        Permit()
-    */
-
-    struct MemHeader *oldHead, *oldTail, *mh, *oldSucc, *oldPred, *oldTailPred;
-    APTR buffer = NULL;
-
-    Forbid();
-    oldHead = (struct MemHeader *)SysBase->MemList.lh_Head;
-    oldTail = (struct MemHeader *)SysBase->MemList.lh_Tail;
-    oldTailPred = (struct MemHeader *)SysBase->MemList.lh_TailPred;
-    mh = region->memListNode;
-    if (mh) {
-        oldSucc = (struct MemHeader *)mh->mh_Node.ln_Succ;
-        oldPred = (struct MemHeader *)mh->mh_Node.ln_Pred;
-        //now start modifying the lists!
-        SysBase->MemList.lh_Head = (struct Node *)mh;
-        SysBase->MemList.lh_Tail = (struct Node *)mh;
-        SysBase->MemList.lh_TailPred = NULL;
-        mh->mh_Node.ln_Succ = (struct Node *)mh;
-        mh->mh_Node.ln_Pred = (struct Node *)mh;
-        //AllocMem
-        buffer = AllocMem(buffer_size, region->mem_type | MEMF_CLEAR);
-        //restore the old pointers
-        SysBase->MemList.lh_Head = (struct Node *)oldHead;
-        SysBase->MemList.lh_Tail = (struct Node *)oldTail;
-        SysBase->MemList.lh_TailPred = (struct Node *)oldTailPred;
-        mh->mh_Node.ln_Succ = (struct Node *)oldSucc;
-        mh->mh_Node.ln_Pred = (struct Node *)oldPred;
-    }
+    buffer = AllocAbs(buffer_size, chunk);
     Permit();
 
-    if (buffer) { // we found memory
-        /* Use shared benchmark function (16 iterations) */
-        bytes_per_sec = measure_mem_read_speed((volatile ULONG *)buffer, buffer_size, 16);
+    if (buffer) {
+        bytes_per_sec = measure_mem_read_speed((volatile ULONG *)buffer,
+                                               buffer_size, 16);
         FreeMem(buffer, buffer_size);
-        region->speed_bytes_sec = bytes_per_sec;
-        region->speed_measured = TRUE;
-    } else {
-        region->speed_measured = TRUE; //got no membrain : nothing to try again!
-        region->speed_bytes_sec = 0;
-        bytes_per_sec = 0;
     }
+
+    region->speed_bytes_sec = bytes_per_sec;
+    region->speed_measured = TRUE;
     return bytes_per_sec;
 }
 


### PR DESCRIPTION
The per-region memory benchmark forced AllocMem() into one region by
temporarily rewriting Exec's global MemList. That can corrupt or detach
manually-added memory regions, as reported on PP&S 2000/040 RAM.

Find the live MemHeader for the selected region, choose a free chunk,
and allocate it with AllocAbs() instead. This keeps the benchmark
buffer owned by Exec without mutating the allocator list.
