### PR TITLE
Makefile: fix parallel builds racing the generated headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,11 @@ $(FLEXCAT_BIN):
 	@$(MAKE) -s -C 3rdparty/flexcat
 
 # Identify library build (requires FlexCat)
-identify: $(FLEXCAT_BIN)
+IDENTIFY_HEADER = $(IDENTIFY_INC)/proto/identify.h
+
+identify: $(IDENTIFY_HEADER)
+
+$(IDENTIFY_HEADER): $(FLEXCAT_BIN) | download-libs
 	@{ if [ ! -f $(HOME)/.fd2pragma.types ]; then \
 	     echo '$$(HOME)/.fd2pragma.types not found. Downloading.'; \
 	     curl -sL 'https://github.com/adtools/fd2pragma/raw/refs/heads/master/fd2pragma.types' \
@@ -95,7 +99,11 @@ identify: $(FLEXCAT_BIN)
 	$(MAKE) -s -C 3rdparty/identify reference/proto/identify.h reference/inline/identify.h
 
 # MMU library convert (requires FlexCat)
-mmu: $(FLEXCAT_BIN)
+MMU_HEADER = $(MMU_INC)/proto/mmu.h
+
+mmu: $(MMU_HEADER)
+
+$(MMU_HEADER): $(FLEXCAT_BIN) | download-libs
 	@{ if [ ! -f $(HOME)/.fd2pragma.types ]; then \
 	     echo '$$(HOME)/.fd2pragma.types not found. Downloading.'; \
 	     curl -sL 'https://github.com/adtools/fd2pragma/raw/refs/heads/master/fd2pragma.types' \
@@ -163,7 +171,7 @@ $(STACK_OBJ): $(STACK_SRC)
 	@echo "  CC    $@"
 	@$(CC) $(STACK_CFLAGS) -c -o $@ $<
 
-$(OBJS): src/%.o: src/%.c src/xsysinfo.h
+$(OBJS): src/%.o: src/%.c src/xsysinfo.h $(IDENTIFY_HEADER) $(MMU_HEADER)
 	@echo "  CC    $@"
 	@$(CC) $(CFLAGS) -c -o $@ $<
 


### PR DESCRIPTION
Building with `make -jN` intermittently fails with:

```
src/main.c:28:10: fatal error: proto/identify.h: No such file or directory
```

The `all` target lists `download-libs identify mmu $(TARGET)` as
prerequisites, but under -j they run concurrently, and the objects
never declared a dependency on the generated identify/mmu headers, so
compilation could start before fd2pragma produced them. Serial makes
always won by left-to-right ordering, which is why the failure only
shows up with -j.

Fix:

- turn the generated headers into real file targets
  (`$(IDENTIFY_HEADER)`, `$(MMU_HEADER)`) with the existing recipes;
  the phony `identify`/`mmu` names remain as aliases;
- order the header generation after `download-libs` with an
  order-only prerequisite (the fd files come out of the downloaded
  archives); order-only so the phony target does not force
  regeneration on every run;
- add both headers to the `$(OBJS)` prerequisites.

Side effect: `make xSysInfo` now works from a clean tree, since the
objects pull in the headers themselves.

Tested: repeated `make clean` + `make -j24 all` from scratch, and
serial builds, both green with gcc 16.2.
